### PR TITLE
Added parsing tests for nested  cases in switch statements.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5557,6 +5557,10 @@ WARNING(non_exhaustive_switch_unknown_only,none,
         "switch covers known cases, but %0 may have additional unknown values"
         "%select{|, possibly added in future versions}1", (Type, bool))
 
+WARNING(unknown_pattern_for_non_enum,none,
+        "unknown pattern is not applicable to non-enum type %0", (Type))
+NOTE(non_enum_drop_unknown,none, "remove '@unknown'", ())
+
 ERROR(override_nsobject_hashvalue_error,none,
       "'NSObject.hashValue' is not overridable; "
       "did you mean to override 'NSObject.hash'?", ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1164,12 +1164,17 @@ public:
 /// DiscardAssignmentExpr - A '_' in the left-hand side of an assignment, which
 /// discards the corresponding tuple element on the right-hand side.
 class DiscardAssignmentExpr : public Expr {
+  /// HACK: Location for @unknown _ in conditional clauses in switch statements.
+  /// @unknown isn't permitted in assignment contexts.
+  SourceLoc UnknownLoc;
   SourceLoc Loc;
 
 public:
-  DiscardAssignmentExpr(SourceLoc Loc, bool Implicit)
-    : Expr(ExprKind::DiscardAssignment, Implicit), Loc(Loc) {}
-  
+  DiscardAssignmentExpr(SourceLoc UnknownLoc, SourceLoc Loc, bool Implicit)
+      : Expr(ExprKind::DiscardAssignment, Implicit), UnknownLoc(UnknownLoc),
+        Loc(Loc) {}
+
+  SourceLoc getUnknownLoc() const { return UnknownLoc; }
   SourceRange getSourceRange() const { return Loc; }
   SourceLoc getLoc() const { return Loc; }
   

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -474,6 +474,8 @@ namespace {
     }
     void visitAnyPattern(AnyPattern *P) {
       printCommon(P, "pattern_any");
+      if (P->getUnknownLoc().isValid())
+        OS << " @unknown";
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
     void visitTypedPattern(TypedPattern *P) {
@@ -2030,6 +2032,8 @@ public:
 
   void visitDiscardAssignmentExpr(DiscardAssignmentExpr *E) {
     printCommon(E, "discard_assignment_expr");
+    if (E->getUnknownLoc().isValid())
+      OS << " @unknown";
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -345,6 +345,30 @@ case PatternKind::ID: foundRefutablePattern = true; break;
   return foundRefutablePattern;
 }
 
+bool Pattern::hasUnknownAnyPattern() const {
+  bool foundUnknownAnyPattern = false;
+  const_cast<Pattern *>(this)->forEachNode([&](Pattern *Node) {
+    switch (Node->getKind()) {
+    case PatternKind::Any:
+      foundUnknownAnyPattern |= cast<AnyPattern>(Node)->isUnknown();
+      return;
+    case PatternKind::Named:
+    case PatternKind::Expr:
+    case PatternKind::Bool:
+    case PatternKind::Is:
+    case PatternKind::Paren:
+    case PatternKind::Typed:
+    case PatternKind::Binding:
+    case PatternKind::Tuple:
+    case PatternKind::EnumElement:
+    case PatternKind::OptionalSome:
+      return;
+    }
+    llvm_unreachable("Unhandled PatternKind!");
+  });
+  return foundUnknownAnyPattern;
+}
+
 /// Standard allocator for Patterns.
 void *Pattern::operator new(size_t numBytes, const ASTContext &C) {
   return C.Allocate(numBytes, alignof(Pattern));

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1421,7 +1421,7 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 ///     '.' identifier
 ///
 ///   expr-discard:
-///     '_'
+///     @unknown? '_' (@unknown can only appear in patterns)
 ///
 ///   expr-primary:
 ///     expr-literal
@@ -1456,6 +1456,16 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     // Objective-C programmers habitually type @"foo", so recover gracefully
     // with a fixit.  If this isn't @"foo", just handle it like an unknown
     // input.
+    if (peekToken().isContextualKeyword("unknown")) {
+      auto UnknownLoc = consumeToken();
+      consumeToken();
+      if (!Tok.is(tok::kw__))
+        goto UnknownCharacter;
+      // Similar to the tok::kw__ case.
+      ExprContext.setCreateSyntax(SyntaxKind::DiscardAssignmentExpr);
+      return makeParserResult(new (Context) DiscardAssignmentExpr(
+          UnknownLoc, consumeToken(), /*Implicit=*/false));
+    }
     if (peekToken().isNot(tok::string_literal))
       goto UnknownCharacter;
     
@@ -1558,8 +1568,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
 
   case tok::kw__: // _
     ExprContext.setCreateSyntax(SyntaxKind::DiscardAssignmentExpr);
-    return makeParserResult(
-      new (Context) DiscardAssignmentExpr(consumeToken(), /*Implicit=*/false));
+    return makeParserResult(new (Context) DiscardAssignmentExpr(
+        /*@unknown*/ SourceLoc(), consumeToken(), /*Implicit=*/false));
 
   case tok::pound_selector: // expr-selector
     return parseExprSelector();

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -957,7 +957,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
     
     if (result.isNull()) {
       // Recover by creating AnyPattern.
-      auto *AP = new (Context) AnyPattern(colonLoc);
+      auto *AP = new (Context) AnyPattern(/*@unknown*/ SourceLoc(), colonLoc);
       if (colonLoc.isInvalid())
         AP->setImplicit();
       result = makeParserErrorResult(AP);
@@ -1044,8 +1044,9 @@ ParserResult<Pattern> Parser::parsePattern() {
       return makeParserResult(NamedPattern::createImplicit(Context, VD));
     }
     PatternCtx.setCreateSyntax(SyntaxKind::WildcardPattern);
-    return makeParserResult(new (Context) AnyPattern(consumeToken(tok::kw__)));
-    
+    return makeParserResult(new (Context) AnyPattern(/*@unknown*/ SourceLoc(),
+                                                     consumeToken(tok::kw__)));
+
   case tok::identifier: {
     PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;
@@ -1102,7 +1103,8 @@ ParserResult<Pattern> Parser::parsePattern() {
         .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
       SourceLoc Loc = Tok.getLoc();
       consumeToken();
-      return makeParserErrorResult(new (Context) AnyPattern(Loc));
+      return makeParserErrorResult(
+          new (Context) AnyPattern(/*@unknown*/ SourceLoc(), Loc));
     }
     diagnose(Tok, diag::expected_pattern);
     return nullptr;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1100,7 +1100,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
   // If that didn't work, use a bogus pattern so that we can fill out
   // the AST.
   if (patternResult.isNull()) {
-    auto *AP = new (P.Context) AnyPattern(P.PreviousLoc);
+    auto *AP =
+        new (P.Context) AnyPattern(/*@unknown*/ SourceLoc(), P.PreviousLoc);
     if (P.PreviousLoc.isInvalid())
       AP->setImplicit();
     patternResult = makeParserErrorResult(AP);
@@ -1551,7 +1552,7 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     
   if (ThePattern.isNull()) {
     // Recover by creating AnyPattern.
-    auto *AP = new (Context) AnyPattern(PreviousLoc);
+    auto *AP = new (Context) AnyPattern(/*@unknown*/ SourceLoc(), PreviousLoc);
     if (PreviousLoc.isInvalid())
       AP->setImplicit();
     ThePattern = makeParserResult(AP);
@@ -2407,7 +2408,7 @@ parseStmtCase(Parser &P, SourceLoc &CaseLoc,
 static ParserStatus
 parseStmtCaseDefault(Parser &P, SourceLoc &CaseLoc,
                      SmallVectorImpl<CaseLabelItem> &LabelItems,
-                     SourceLoc &ColonLoc) {
+                     SourceLoc UnknownLoc, SourceLoc &ColonLoc) {
   SyntaxParsingContext CaseContext(P.SyntaxContext,
                                    SyntaxKind::SwitchDefaultLabel);
   ParserStatus Status;
@@ -2433,7 +2434,7 @@ parseStmtCaseDefault(Parser &P, SourceLoc &CaseLoc,
     P.consumeToken(tok::colon);
 
   // Create an implicit AnyPattern to represent the default match.
-  auto Any = new (P.Context) AnyPattern(CaseLoc);
+  auto Any = new (P.Context) AnyPattern(UnknownLoc, CaseLoc);
   if (CaseLoc.isInvalid())
     Any->setImplicit();
   LabelItems.push_back(
@@ -2525,7 +2526,8 @@ ParserResult<CaseStmt> Parser::parseStmtCase(bool IsActive) {
     Status |= ::parseStmtCase(*this, CaseLoc, CaseLabelItems, BoundDecls,
                               ColonLoc, CaseBodyDecls);
   } else if (Tok.is(tok::kw_default)) {
-    Status |= parseStmtCaseDefault(*this, CaseLoc, CaseLabelItems, ColonLoc);
+    Status |= parseStmtCaseDefault(*this, CaseLoc, CaseLabelItems,
+                                   UnknownAttrLoc, ColonLoc);
   } else {
     llvm_unreachable("isAtStartOfSwitchCase() lied.");
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -349,7 +349,7 @@ public:
     if (E->isImplicit()) {
       return AnyPattern::createImplicit(Context);
     }
-    return new (Context) AnyPattern(E->getLoc());
+    return new (Context) AnyPattern(E->getUnknownLoc(), E->getLoc());
   }
   
   // Cast expressions 'x as T' get resolved to checked cast patterns.

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -137,7 +137,7 @@ namespace {
           cache.insert(getType().getPointer());
 
           SmallVector<Space, 4> spaces;
-          decompose(DC, getType(), spaces);
+          decompose(DC, getType(), /*makeUnknownPatterns*/ true, spaces);
           size_t acc = 0;
           for (auto &sp : spaces) {
             // Decomposed pattern spaces grow with the sum of the subspaces.
@@ -778,8 +778,42 @@ namespace {
         }
       };
 
+      /// Decompose '@unknown _' patterns in arbitrary nested positions.
+      ///
+      /// For example, if you have a non-frozen enum E { case a; case b },
+      /// and you're matching on a pair of type (E, E):
+      /// \code
+      ///                 (@unknown _, @unknown _)
+      ///   [decompose]-> ((.a | .b), (.a | .b))
+      ///     [flatten]-> (.a, .a) | (.b, .a) | (.a, .b) | (.b, .b)
+      /// \endcode
+      static void decomposeUnknowns(const DeclContext *DC,
+                                    const Pattern *pattern,
+                                    SmallVectorImpl<Space> &outSpaces) {
+        auto projectAnyPattern = [DC](const AnyPattern *anyPattern) -> Space {
+          auto type = anyPattern->getType();
+          if (anyPattern->isUnknown()) {
+            if (Space::canDecompose(type, DC)) {
+              SmallVector<Space, 4> spaces;
+              Space::decompose(DC, type, /*makeUnknownPatterns*/ false, spaces);
+              return Space::forDisjunct(spaces);
+            }
+            auto &diag = DC->getASTContext().Diags;
+            auto unknownLoc = anyPattern->getUnknownLoc();
+            diag.diagnose(unknownLoc, diag::unknown_pattern_for_non_enum, type);
+            diag.diagnose(unknownLoc, diag::non_enum_drop_unknown)
+                .fixItRemove(
+                    SourceRange(unknownLoc, unknownLoc.getAdvancedLoc(8)));
+          }
+          return Space::forType(anyPattern->getType(), Identifier());
+        };
+        auto decomposed = projectPattern(pattern, projectAnyPattern);
+        flatten(decomposed, outSpaces);
+      }
+
       // Decompose a type into its component spaces.
       static void decompose(const DeclContext *DC, Type tp,
+                            bool makeUnknownPatterns,
                             SmallVectorImpl<Space> &arr) {
         assert(canDecompose(tp, DC) && "Non-decomposable type?");
 
@@ -816,10 +850,12 @@ namespace {
                                              constElemSpaces);
               });
 
-          if (!E->isFormallyExhaustive(DC)) {
-            arr.push_back(Space::forUnknown(/*allowedButNotRequired*/false));
-          } else if (!E->getAttrs().hasAttribute<FrozenAttr>()) {
-            arr.push_back(Space::forUnknown(/*allowedButNotRequired*/true));
+          if (makeUnknownPatterns) {
+            if (!E->isFormallyExhaustive(DC)) {
+              arr.push_back(Space::forUnknown(/*allowedButNotRequired*/ false));
+            } else if (!E->getAttrs().hasAttribute<FrozenAttr>()) {
+              arr.push_back(Space::forUnknown(/*allowedButNotRequired*/ true));
+            }
           }
 
         } else if (auto *TTy = tp->castTo<TupleType>()) {
@@ -840,7 +876,7 @@ namespace {
 
       static Space decompose(const DeclContext *DC, Type type) {
         SmallVector<Space, 4> spaces;
-        decompose(DC, type, spaces);
+        decompose(DC, type, /*makeUnknownPatterns*/ true, spaces);
         return Space::forDisjunct(spaces);
       }
 
@@ -955,6 +991,33 @@ namespace {
       const CaseStmt *unknownCase = nullptr;
       SmallVector<Space, 4> spaces;
       auto &DE = Context.Diags;
+
+      auto handleUnknownAnyPattern =
+          [this](const CaseStmt *caseBlock,
+                 const SmallVectorImpl<Space> &spacesSoFar,
+                 const Pattern *pattern, const Space &projection) {
+            if (!pattern->hasUnknownAnyPattern())
+              return;
+            Space coveredSoFar = Space::forDisjunct(spacesSoFar);
+            Space partialUncovered =
+                projection.minus(coveredSoFar, DC, /*minusCount*/ nullptr)
+                    .getValue();
+            if (!partialUncovered.isEmpty()) {
+              // TODO: Maybe we should prefer inserting alternatives in-between
+              // if the @unknown _ is not in the first condition clause?
+              //   case .a, (@unknown _) [fix]-> case .a, .b, (@unknown _)
+              SmallVector<Space, 4> scratchSpaces;
+              Space::decomposeUnknowns(DC, pattern, scratchSpaces);
+              Space projectionDecomposed = Space::forDisjunct(scratchSpaces);
+              partialUncovered =
+                  projectionDecomposed
+                      .minus(coveredSoFar, DC, /*minusCount*/ nullptr)
+                      .getValue();
+              diagnoseMissingCases(RequiresDefault::No, partialUncovered,
+                                   caseBlock);
+            }
+          };
+
       for (auto *caseBlock : Switch->getCases()) {
         if (caseBlock->hasUnknownAttr()) {
           assert(unknownCase == nullptr && "multiple unknown cases");
@@ -972,7 +1035,9 @@ namespace {
           if (caseItem.isDefault())
             return;
 
-          Space projection = projectPattern(caseItem.getPattern());
+          auto casePattern = caseItem.getPattern();
+          Space projection =
+              projectPattern(casePattern, /*projectAnyPattern*/ nullptr);
           bool isRedundant = !projection.isEmpty() &&
                              llvm::any_of(spaces, [&](const Space &handled) {
             return projection.isSubspace(handled, DC);
@@ -996,8 +1061,10 @@ namespace {
             continue;
           }
 
-          if (!projection.isEmpty())
+          if (!projection.isEmpty()) {
+            handleUnknownAnyPattern(caseBlock, spaces, casePattern, projection);
             spaces.push_back(projection);
+          }
         }
       }
 
@@ -1034,7 +1101,8 @@ namespace {
       if (uncovered.getKind() == SpaceKind::Type) {
         if (Space::canDecompose(uncovered.getType(), DC)) {
           SmallVector<Space, 4> spaces;
-          Space::decompose(DC, uncovered.getType(), spaces);
+          Space::decompose(DC, uncovered.getType(), /*makeUnknownCases*/ true,
+                           spaces);
           diagnoseMissingCases(RequiresDefault::No, Space::forDisjunct(spaces),
                                unknownCase);
         } else {
@@ -1373,9 +1441,14 @@ namespace {
     }
 
     /// Recursively project a pattern into a Space.
-    static Space projectPattern(const Pattern *item) {
+    static Space projectPattern(
+        const Pattern *item,
+        llvm::function_ref<Space(const AnyPattern *)> projectAnyPattern) {
       switch (item->getKind()) {
       case PatternKind::Any:
+        if (projectAnyPattern) {
+          return projectAnyPattern(cast<AnyPattern>(item));
+        }
         return Space::forType(item->getType(), Identifier());
       case PatternKind::Named:
         return Space::forType(item->getType(),
@@ -1389,7 +1462,7 @@ namespace {
         case CheckedCastKind::BridgingCoercion: {
           if (auto *subPattern = IP->getSubPattern()) {
             // Project the cast target's subpattern.
-            Space castSubSpace = projectPattern(subPattern);
+            Space castSubSpace = projectPattern(subPattern, projectAnyPattern);
             // If we recieved a type space from a named pattern or a wildcard
             // we have to re-project with the cast's target type to maintain
             // consistency with the scrutinee's type.
@@ -1420,18 +1493,18 @@ namespace {
         return Space();
       case PatternKind::Binding: {
         auto *VP = cast<BindingPattern>(item);
-        return projectPattern(VP->getSubPattern());
+        return projectPattern(VP->getSubPattern(), projectAnyPattern);
       }
       case PatternKind::Paren: {
         auto *PP = cast<ParenPattern>(item);
-        return projectPattern(PP->getSubPattern());
+        return projectPattern(PP->getSubPattern(), projectAnyPattern);
       }
       case PatternKind::OptionalSome: {
         auto *OSP = cast<OptionalSomePattern>(item);
         auto &Ctx = OSP->getElementDecl()->getASTContext();
         const Identifier name = Ctx.getOptionalSomeDecl()->getBaseIdentifier();
 
-        auto subSpace = projectPattern(OSP->getSubPattern());
+        auto subSpace = projectPattern(OSP->getSubPattern(), projectAnyPattern);
         // To match patterns like (_, _, ...)?, we must rewrite the underlying
         // tuple pattern to .some(_, _, ...) first.
         if (subSpace.getKind() == SpaceKind::Constructor &&
@@ -1458,7 +1531,8 @@ namespace {
           auto *TP = dyn_cast<TuplePattern>(SP);
           llvm::transform(TP->getElements(), std::back_inserter(conArgSpace),
                           [&](TuplePatternElt pate) {
-                            return projectPattern(pate.getPattern());
+                            return projectPattern(pate.getPattern(),
+                                                  projectAnyPattern);
                           });
           // FIXME: Compound names.
           return Space::forConstructor(item->getType(),
@@ -1482,9 +1556,9 @@ namespace {
             if (auto *TTy = outerType->getAs<TupleType>())
               Space::getTupleTypeSpaces(outerType, TTy, conArgSpace);
             else
-              conArgSpace.push_back(projectPattern(SP));
+              conArgSpace.push_back(projectPattern(SP, projectAnyPattern));
           } else if (SP->getKind() == PatternKind::Tuple) {
-            Space argTupleSpace = projectPattern(SP);
+            Space argTupleSpace = projectPattern(SP, projectAnyPattern);
             // Tuples are modeled as if they are enums with a single, nameless
             // case, which means argTupleSpace will either be a Constructor or
             // Empty space. If it's empty (i.e. it contributes nothing to the
@@ -1494,7 +1568,7 @@ namespace {
             assert(argTupleSpace.getKind() == SpaceKind::Constructor);
             conArgSpace.push_back(argTupleSpace);
           } else {
-            conArgSpace.push_back(projectPattern(SP));
+            conArgSpace.push_back(projectPattern(SP, projectAnyPattern));
           }
           // FIXME: Compound names.
           return Space::forConstructor(item->getType(),
@@ -1502,7 +1576,7 @@ namespace {
                                        conArgSpace);
         }
         default:
-          return projectPattern(SP);
+          return projectPattern(SP, projectAnyPattern);
         }
       }
       case PatternKind::Tuple: {
@@ -1510,7 +1584,8 @@ namespace {
         SmallVector<Space, 4> conArgSpace;
         llvm::transform(TP->getElements(), std::back_inserter(conArgSpace),
                         [&](TuplePatternElt pate) {
-                          return projectPattern(pate.getPattern());
+                          return projectPattern(pate.getPattern(),
+                                                projectAnyPattern);
                         });
         return Space::forConstructor(item->getType(), Identifier(),
                                      conArgSpace);

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -727,10 +727,10 @@ func switchTwoWithAtUnknown(_ x: E, _ y: E) {
   }
 }
 
-func switchTwoWithAtUnknown(_ x: E, _ y: E, _ z: E) {
+func switchThreeWithAtUnknown(_ x: E, _ y: E, _ z: E) {
 // should be happy path, no diagnostics
 // but the non-unknown cases are covering the unknown cases, so some extra diagnostics are appearing.
-// Unless I am m
+// unless I am misunderstanding something.
   switch (x, (y, z)) {
   case (.a, (.a, .b)),
        (.a, (.b, .a)),

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-library-evolution
 
 // TODO: Implement tuple equality in the library.
 // BLOCKED: <rdar://problem/13822406>
@@ -227,12 +227,12 @@ case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}
 // OK
 case (_, 2), (1, _):
   ()
-  
+
 case (_, var a), (_, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
   ()
-  
+
 case (var a, var b), (var b, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
   // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
@@ -644,4 +644,107 @@ func testIncompleteArrayLiteral() {
   @unknown default: // expected-note {{remove '@unknown' to handle remaining values}}
     ()
   }
+}
+
+// Note that library evolution is enabled above.
+// Other enums in this file are nonpublic so already @frozen.
+public enum E {
+ case a
+ case b
+}
+
+func switchTwoWithAtUnknown(_ x: E, _ y: E) {
+
+// happy path, no diagnostics
+  switch (x, y) {
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): ()
+  case (@unknown _, .a): ()
+  case (@unknown _, .b): ()
+  case (.a, @unknown _): ()
+  case (.b, @unknown _): ()
+  case (@unknown _, @unknown _): ()
+  default: ()
+  }
+// note order-dependency--if `case (@unknown _, @unknown _): ()` is first, diagnostics fire
+// I _think_ this is right for the case is already handled--the earlier cases do handle the patterns
+// but the switch is exhaustive in this case, that warning/note should not fire
+  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}} expected-note {{add missing case: '(.b, .a)'}} expected-note {{add missing case: '(.a, .b)'}} expected-note {{add missing case: '(.b, .b)'}}
+  case (@unknown _, @unknown _): ()
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .a): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.b, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  default: ()
+  }
+
+  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}} expected-note {{add missing case: '(.b, .a)'}}
+  case (@unknown _, .a): ()
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .b): ()
+  case (.a, @unknown _): ()
+  case (.b, @unknown _): ()
+  case (@unknown _, @unknown _): ()
+  default: ()
+  }
+  // simple missing cases
+  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}}
+  case (.b, .a): ()
+  case (@unknown _, .a): ()
+  default: ()
+  }
+
+  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}}
+  case (.b, _): ()
+  case (@unknown _, .a): ()
+  default: ()
+  }
+
+  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, _)'}} expected-note {{add missing case: '(.b, _)'}}
+  case (@unknown _, _): ()
+  }
+// cases after `default:`
+  switch (x, y) {
+  default: ()
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
+  case (@unknown _, .a): ()
+  case (@unknown _, .b): ()
+  case (.a, @unknown _): ()
+  case (.b, @unknown _): ()
+  case (@unknown _, @unknown _): ()
+  default: ()
+  }
+// cases after `case _:`, subtly different from `default`. This is correct.
+  switch (x, y) {
+  case _: ()
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .a): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.b, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  default: ()
+  }
+}
+
+func switchTwoWithAtUnknown(_ x: E, _ y: E, _ z: E) {
+// should be happy path, no diagnostics
+// but the non-unknown cases are covering the unknown cases, so some extra diagnostics are appearing.
+// Unless I am m
+  switch (x, (y, z)) {
+  case (.a, (.a, .b)),
+       (.a, (.b, .a)),
+       (.b, (.b, .a)),
+       (.b, (.a, .b)): ()
+  case (.a, _): ()
+  case (.b, _): ()
+  case (_, (.a, .b)): ()
+  case (@unknown _, (.a, .b)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, (.b, .a)): ()
+  case (.a, (@unknown _, .a)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.b, (.a, @unknown _)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, (@unknown _, @unknown _)): ()
+  default: ()
+  }
+
 }

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -102,8 +102,6 @@ case 1:
   x = 0
 }
 
-
-
 switch x {
   x = 1 // expected-error{{all statements inside a switch must be covered by a 'case' or 'default'}}
 default:
@@ -668,19 +666,35 @@ func switchTwoWithAtUnknown(_ x: E, _ y: E) {
 // note order-dependency--if `case (@unknown _, @unknown _): ()` is first, diagnostics fire
 // I _think_ this is right for the case is already handled--the earlier cases do handle the patterns
 // but the switch is exhaustive in this case, that warning/note should not fire
-  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}} expected-note {{add missing case: '(.b, .a)'}} expected-note {{add missing case: '(.a, .b)'}} expected-note {{add missing case: '(.b, .b)'}}
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.a, .a)'}}
+  // expected-note@-2 {{add missing case: '(.b, .a)'}}
+  // expected-note@-3 {{add missing case: '(.a, .b)'}}
+  // expected-note@-4 {{add missing case: '(.b, .b)'}}
   case (@unknown _, @unknown _): ()
-  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (@unknown _, .a): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (@unknown _, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (.a, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (.b, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-3 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-4 {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .a): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .b): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (.a, @unknown _): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (.b, @unknown _): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   default: ()
   }
 
-  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}} expected-note {{add missing case: '(.b, .a)'}}
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+                  // expected-note@-1 {{add missing case: '(.a, .a)'}}
+                  // expected-note@-2 {{add missing case: '(.b, .a)'}}
   case (@unknown _, .a): ()
-  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
   case (@unknown _, .b): ()
   case (.a, @unknown _): ()
   case (.b, @unknown _): ()
@@ -688,25 +702,30 @@ func switchTwoWithAtUnknown(_ x: E, _ y: E) {
   default: ()
   }
   // simple missing cases
-  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}}
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+                  // expected-note@-1 {{add missing case: '(.a, .a)'}}
   case (.b, .a): ()
   case (@unknown _, .a): ()
   default: ()
   }
 
-  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, .a)'}}
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+                  // expected-note@-1 {{add missing case: '(.a, .a)'}}
   case (.b, _): ()
   case (@unknown _, .a): ()
   default: ()
   }
 
-  switch (x, y) { // expected-warning {{switch must be exhaustive}} expected-note {{add missing case: '(.a, _)'}} expected-note {{add missing case: '(.b, _)'}}
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+                  // expected-note@-1 {{add missing case: '(.a, _)'}}
+                  // expected-note@-2 {{add missing case: '(.b, _)'}}
   case (@unknown _, _): ()
   }
 // cases after `default:`
   switch (x, y) {
   default: ()
-  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): ()
+  // expected-error@-1 {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
   case (@unknown _, .a): ()
   case (@unknown _, .b): ()
   case (.a, @unknown _): ()
@@ -714,15 +733,24 @@ func switchTwoWithAtUnknown(_ x: E, _ y: E) {
   case (@unknown _, @unknown _): ()
   default: ()
   }
-// cases after `case _:`, subtly different from `default`. This is correct.
+// cases after `case _:`, subtly different from `default`. This is correct I think.
   switch (x, y) {
   case _: ()
-  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}} expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (@unknown _, .a): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (@unknown _, .b): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (.a, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (.b, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (@unknown _, @unknown _): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, .a), (.a, .b), (.b, .a), (.b, .b): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-3 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-4 {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .a): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, .b): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (.a, @unknown _): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (.b, @unknown _): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, @unknown _): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   default: ()
   }
 }
@@ -739,10 +767,13 @@ func switchThreeWithAtUnknown(_ x: E, _ y: E, _ z: E) {
   case (.a, _): ()
   case (.b, _): ()
   case (_, (.a, .b)): ()
-  case (@unknown _, (.a, .b)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (@unknown _, (.a, .b)): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   case (@unknown _, (.b, .a)): ()
-  case (.a, (@unknown _, .a)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
-  case (.b, (.a, @unknown _)): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.a, (@unknown _, .a)): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case (.b, (.a, @unknown _)): ()
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   case (@unknown _, (@unknown _, @unknown _)): ()
   default: ()
   }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1450,3 +1450,65 @@ func sr12412() {
       case (e: .y, b: true)?: break
   }
 }
+
+func nestedUnknown(_ e: NonFrozenEnum) {
+  switch (e, e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '(.a, .a)'}}
+  // expected-note@-2{{add missing case: '(.b, .a)'}}
+  // expected-note@-3{{add missing case: '(.c, .a)'}}
+  case (@unknown _, .a): ()
+  default: ()
+  }
+  switch (e, e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '(.c, _)'}}
+  // expected-note@-2{{add missing case: '(.b, _)'}}
+  // expected-note@-3{{add missing case: '(.a, _)'}}
+  case (@unknown _, _): ()
+  }
+  switch (e, e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '(.a, .a)'}}
+  // expected-note@-2{{add missing case: '(.b, .a)'}}
+  // expected-note@-3{{add missing case: '(.c, .a)'}}
+  // expected-note@-4{{add missing case: '(.a, .b)'}}
+  // expected-note@-5{{add missing case: '(.b, .b)'}}
+  // expected-note@-6{{add missing case: '(.c, .b)'}}
+  // expected-note@-7{{add missing case: '(.a, .c)'}}
+  // expected-note@-8{{add missing case: '(.b, .c)'}}
+  // expected-note@-9{{add missing case: '(.c, .c)'}}
+  case (@unknown _, @unknown _): ()
+  }
+  switch (e, e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '(.b, .a)'}}
+  // expected-note@-2{{add missing case: '(.c, .a)'}}
+  case (.a, _): ()
+  case (@unknown _, .a): ()
+  default: ()
+  }
+  switch (e, e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '(.b, .a)'}}
+  // expected-note@-2{{add missing case: '(.c, .a)'}}
+  case (.a, _), (@unknown _, .a): ()
+  default: ()
+  }
+  switch Optional.some(e) { // expected-warning{{switch must be exhaustive}}
+  // expected-note@-1{{add missing case: '.some(.a)'}}
+  // expected-note@-2{{add missing case: '.some(.b)'}}
+  // expected-note@-3{{add missing case: '.some(.c)'}}
+  case .some(@unknown _): ()
+  case .none: ()
+  }
+}
+
+// Check that statements are ill-formed
+
+let (@unknown _) = NonFrozenEnum.a
+// expected-error@-1{{expected pattern}}
+// expected-error@-2{{cannot convert value}}
+let @unknown _ = NonFrozenEnum.a
+// expected-error@-1{{expected pattern}}
+for @unknown _ in [NonFrozenEnum.a] {}
+// expected-error@-1{{'_' can only appear in a pattern or on the left side of an assignment}}
+// expected-error@-2{{expected pattern}}
+// expected-error@-3{{expected '{' to start the body of for-each loop}}
+if let @unknown _ = .some(NonFrozenEnum.a) {}
+// FIXME: [Varun] Not sure where to issue error in Parse/Sema for above code

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -104,6 +104,8 @@ EXPR_NODES = [
     # A _ expression.
     Node('DiscardAssignmentExpr', kind='Expr',
          children=[
+             Child('Unknown', kind='Attribute',
+                   is_optional=True),
              Child('Wildcard', kind='WildcardToken'),
          ]),
 

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -66,6 +66,8 @@ PATTERN_NODES = [
     # wildcard-pattern -> '_' type-annotation?
     Node('WildcardPattern', kind='Pattern',
          children=[
+             Child('Unknown', kind='Attribute',
+                   is_optional=True),
              Child('Wildcard', kind='WildcardToken'),
              Child('TypeAnnotation', kind='TypeAnnotation',
                    is_optional=True),


### PR DESCRIPTION
<!-- What's in this pull request? -->
A couple of parser tests for nested `@unknown _`.  

This is a work in progress. It looks like the order of the `case` clauses with `@unknown _` causes some confusion in the exhaustivity checker, but I'm not 100% sure yet. 

I put the `// expected-X` entries in for the diagnostics I actually receive, not the correct ones, so these pass right now but I think they should not in some cases. 

I might not be understanding some of the behavior. My sense is that the ordering of `case` clauses should be 1. concrete matches, then 2. `@unknown _` in combination with concrete matches, then 3. `@unknown default` or just `default`. 

But I have not reasoned that out completely yet. It's possible that you can't or should not keep that ordering when you have nested `case` clauses in either tuples or structs and get the correct behavior. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
